### PR TITLE
PKEY on view table should be collection+key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,23 +21,6 @@ jobs:
       - name: Run unit tests
         run: |
           mix test
-  integration:
-    name: Integration Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.2.0
-        with:
-          otp-version: 21.3
-          elixir-version: 1.8.2
-      - name: Get dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
-      - name: Run integration tests
-        run: |
-          mix test.integration
   static:
     name: Static Analysis
     runs-on: ubuntu-latest

--- a/lib/brook/storage/postgres/limit.ex
+++ b/lib/brook/storage/postgres/limit.ex
@@ -8,11 +8,13 @@ defmodule Brook.Storage.Postgres.Limit do
   import Brook.Storage.Postgres.Statement
 
   def prune(conn, table, type, limit) do
-    spawn fn ->
-      {:ok, %Postgrex.Result{rows: [[type_count]]}} = Postgrex.query(conn, prune_count_stmt(table), [type])
+    spawn(fn ->
+      {:ok, %Postgrex.Result{rows: [[type_count]]}} =
+        Postgrex.query(conn, prune_count_stmt(table), [type])
+
       if type_count > limit do
-        Postgrex.query(conn, prune_delete_stmt(table), [type, (type_count - limit)])
+        Postgrex.query(conn, prune_delete_stmt(table), [type, type_count - limit])
       end
-    end
+    end)
   end
 end

--- a/lib/brook/storage/postgres/statement.ex
+++ b/lib/brook/storage/postgres/statement.ex
@@ -8,7 +8,7 @@ defmodule Brook.Storage.Postgres.Statement do
     ~s|
     INSERT INTO #{table} (collection, key, value)
     VALUES ($1, $2, $3)
-    ON CONFLICT (key)
+    ON CONFLICT (collection, key)
     DO UPDATE SET value = EXCLUDED.value;
     |
   end
@@ -60,9 +60,10 @@ defmodule Brook.Storage.Postgres.Statement do
     ~s|
     CREATE TABLE IF NOT EXISTS #{table}
     (
-      key VARCHAR PRIMARY KEY,
       collection VARCHAR,
-      value JSONB
+      key VARCHAR,
+      value JSONB,
+      PRIMARY KEY (collection, key)
     );
     |
   end
@@ -77,7 +78,7 @@ defmodule Brook.Storage.Postgres.Statement do
       type VARCHAR,
       create_ts BIGINT,
       data BYTEA,
-      FOREIGN KEY (key_id) REFERENCES #{view_table}(key) ON DELETE CASCADE
+      FOREIGN KEY (collection, key_id) REFERENCES #{view_table}(collection, key) ON DELETE CASCADE
     );
     |
   end


### PR DESCRIPTION
Previously, view state's primary key was just the `key` column. This meant an instance with multiple collections would overwrite each other if those collections used the same key value (as you might expect them to).

Now, view state's primary key is two columns: `collection` and `key`. This is more in line with `Brook`'s Redis implementation.

Changes:
- Removed `PRIMARY KEY` from `key` field during table creation
- Added unique constraint to `collection` and `key` fields during table creation
- Upsert happens on conflict of `collection` and `key` together
- Added a test to prove upsert behavior (☝️ )
- Made `collection` the first field during table creation for consistency